### PR TITLE
Java 11 for rultor

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -4,6 +4,8 @@ assets:
   settings.xml: "yegor256/artipie-keys#settings.xml"
   pubring.gpg: "yegor256/artipie-keys#pubring.gpg"
   secring.gpg: "yegor256/artipie-keys#secring.gpg"
+env:
+  JAVA_HOME: /usr/lib/jvm/java-11-openjdk
 install: |
   export LC_ALL=en_US.UTF-8
   export LANG=en_US.UTF-8

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@ SOFTWARE.
     <developerConnection>scm:git:ssh://github.com:artipie/pypi-adapter.git</developerConnection>
     <url>https://github.com/artipie/pypi-adapter/tree/master</url>
   </scm>
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.jsoup</groupId>


### PR DESCRIPTION
Set java 11 to `JAVA_HOME` for rultor and added compiler source and target version to pom.