### PR TITLE
#88 - use PublisherAs and KeyLastPart from asto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.23.2</version>
+      <version>0.23.3</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/pypi/http/Multipart.java
+++ b/src/main/java/com/artipie/pypi/http/Multipart.java
@@ -23,10 +23,8 @@
  */
 package com.artipie.pypi.http;
 
-import com.artipie.asto.Concatenation;
 import com.artipie.asto.Content;
-import com.artipie.asto.Remaining;
-import hu.akarnokd.rxjava2.interop.SingleInterop;
+import com.artipie.asto.ext.PublisherAs;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -89,14 +87,10 @@ final class Multipart {
      * @return Data.
      */
     public CompletionStage<Data> content() {
-        return new Concatenation(this.body)
-            .single()
-            .map(Remaining::new)
-            .map(Remaining::bytes)
-            .map(ByteArrayInputStream::new)
-            .map(input -> new MultipartStream(input, this.boundary(), Multipart.BUFFER, null))
-            .map(Multipart::content)
-            .to(SingleInterop.get());
+        return new PublisherAs(this.body).bytes()
+            .thenApply(ByteArrayInputStream::new)
+            .thenApply(input -> new MultipartStream(input, this.boundary(), Multipart.BUFFER, null))
+            .thenApply(Multipart::content);
     }
 
     /**

--- a/src/main/java/com/artipie/pypi/http/SliceIndex.java
+++ b/src/main/java/com/artipie/pypi/http/SliceIndex.java
@@ -26,6 +26,7 @@ package com.artipie.pypi.http;
 
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
+import com.artipie.asto.ext.KeyLastPart;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
@@ -86,7 +87,7 @@ final class SliceIndex implements Slice {
                                 String.format(
                                     "<a href=\"%s\">%s</a><br/>",
                                     String.format("%s/%s", prefix, key.string()),
-                                    SliceIndex.filename(key)
+                                    new KeyLastPart(key).get()
                                 )
                         )
                         .collect(Collectors.joining())
@@ -103,16 +104,6 @@ final class SliceIndex implements Slice {
                     )
                 )
         );
-    }
-
-    /**
-     * Returns filename, last part of storage key.
-     * @param stkey Storage key
-     * @return Key part
-     */
-    private static String filename(final Key stkey) {
-        final String[] parts = stkey.string().split("/");
-        return parts[parts.length - 1];
     }
 
     /**

--- a/src/test/java/com/artipie/pypi/http/WheelSliceTest.java
+++ b/src/test/java/com/artipie/pypi/http/WheelSliceTest.java
@@ -23,18 +23,15 @@
  */
 package com.artipie.pypi.http;
 
-import com.artipie.asto.Concatenation;
-import com.artipie.asto.Content;
 import com.artipie.asto.Key;
-import com.artipie.asto.Remaining;
 import com.artipie.asto.Storage;
+import com.artipie.asto.ext.PublisherAs;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.http.Headers;
 import com.artipie.http.headers.ContentType;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rs.RsStatus;
-import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Flowable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -69,7 +66,9 @@ class WheelSliceTest {
         );
         MatcherAssert.assertThat(
             "Saves content to storage",
-            this.bytes(storage.value(new Key.From("part", filename)).join()),
+            new PublisherAs(
+                storage.value(new Key.From("part", filename)).join()
+            ).bytes().toCompletableFuture().join(),
             new IsEqual<>(body)
         );
     }
@@ -92,7 +91,9 @@ class WheelSliceTest {
         );
         MatcherAssert.assertThat(
             "Saves content to storage",
-            this.bytes(storage.value(new Key.From(path, "myproject", filename)).join()),
+            new PublisherAs(
+                storage.value(new Key.From(path, "myproject", filename)).join()
+            ).bytes().toCompletableFuture().join(),
             new IsEqual<>(body)
         );
     }
@@ -115,7 +116,9 @@ class WheelSliceTest {
         );
         MatcherAssert.assertThat(
             "Saves content to storage",
-            this.bytes(storage.value(new Key.From(path, "my-super-project", filename)).join()),
+            new PublisherAs(
+                storage.value(new Key.From(path, "my-super-project", filename)).join()
+            ).bytes().toCompletableFuture().join(),
             new IsEqual<>(body)
         );
     }
@@ -148,16 +151,6 @@ class WheelSliceTest {
                 .writeTo(res);
             return res.toByteArray();
         }
-    }
-
-    private byte[] bytes(final Content content) {
-        return new Concatenation(content)
-            .single()
-            .map(buf -> new Remaining(buf, true))
-            .map(Remaining::bytes)
-            .to(SingleInterop.get())
-            .toCompletableFuture()
-            .join();
     }
 
 }


### PR DESCRIPTION
Updated asto and used `PublisherAs` and `KeyLastPart` from the new version to close #88.