### PR TITLE
#86 - read project name and version from metadata

### DIFF
--- a/src/main/java/com/artipie/pypi/meta/PackageInfo.java
+++ b/src/main/java/com/artipie/pypi/meta/PackageInfo.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.pypi.meta;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import org.cactoos.io.ReaderOf;
+
+/**
+ * Python package info.
+ * @since 0.6
+ */
+public interface PackageInfo {
+
+    /**
+     * Package name.
+     * @return Name of the project
+     */
+    String name();
+
+    /**
+     * Package version.
+     * @return Version of the project
+     */
+    String version();
+
+    /**
+     * Implementation of {@link PackageInfo} that parses python metadata PKG-INFO file to obtain
+     * required information. For more details see
+     * <a href="https://www.python.org/dev/peps/pep-0314/">PEP-314</a>.
+     * @since 0.6
+     */
+    final class FromMetadata implements PackageInfo {
+
+        /**
+         * Input.
+         */
+        private final InputStream input;
+
+        /**
+         * Ctor.
+         * @param input Input
+         */
+        public FromMetadata(final InputStream input) {
+            this.input = input;
+        }
+
+        @Override
+        public String name() {
+            return this.read("Name");
+        }
+
+        @Override
+        public String version() {
+            return this.read("Version");
+        }
+
+        /**
+         * Reads header value by name.
+         * @param header Header name
+         * @return Header value
+         */
+        @SuppressWarnings("PMD.AssignmentInOperand")
+        private String read(final String header) {
+            try (BufferedReader br = new BufferedReader(new ReaderOf(this.input))) {
+                final String name = String.format("%s:", header);
+                String line;
+                while ((line = br.readLine()) != null) {
+                    if (line.startsWith(name)) {
+                        this.input.reset();
+                        return line.replace(name, "").trim();
+                    }
+                }
+                throw new IllegalArgumentException(
+                    String.format("Invalid metadata file, header %s not found", header)
+                );
+            } catch (final IOException ex) {
+                throw new UncheckedIOException(ex);
+            }
+        }
+    }
+}

--- a/src/main/java/com/artipie/pypi/meta/package-info.java
+++ b/src/main/java/com/artipie/pypi/meta/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Pypi meta files.
+ *
+ * @since 0.6
+ */
+package com.artipie.pypi.meta;

--- a/src/test/java/com/artipie/pypi/meta/PackageInfoFromMetadataTest.java
+++ b/src/test/java/com/artipie/pypi/meta/PackageInfoFromMetadataTest.java
@@ -23,7 +23,6 @@
  */
 package com.artipie.pypi.meta;
 
-import org.cactoos.io.InputStreamOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -47,7 +46,7 @@ class PackageInfoFromMetadataTest {
     })
     void readsMetadata(final String name, final String version) {
         MatcherAssert.assertThat(
-            new PackageInfo.FromMetadata(new InputStreamOf(this.metadata(name, version))),
+            new PackageInfo.FromMetadata(this.metadata(name, version)),
             Matchers.allOf(
                 new MatcherOf<>(info -> { return version.equals(info.version()); }),
                 new MatcherOf<>(info -> { return name.equals(info.name()); })
@@ -56,10 +55,18 @@ class PackageInfoFromMetadataTest {
     }
 
     @Test
-    void throwsExceptionIfInfoNotFound() {
+    void throwsExceptionIfNameNotFound() {
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> new PackageInfo.FromMetadata(new InputStreamOf("some text")).name()
+            () -> new PackageInfo.FromMetadata("some text").name()
+        );
+    }
+
+    @Test
+    void throwsExceptionIfVersionNotFound() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new PackageInfo.FromMetadata("abc 123").name()
         );
     }
 

--- a/src/test/java/com/artipie/pypi/meta/PackageInfoFromMetadataTest.java
+++ b/src/test/java/com/artipie/pypi/meta/PackageInfoFromMetadataTest.java
@@ -66,7 +66,7 @@ class PackageInfoFromMetadataTest {
     void throwsExceptionIfVersionNotFound() {
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> new PackageInfo.FromMetadata("abc 123").name()
+            () -> new PackageInfo.FromMetadata("abc 123").version()
         );
     }
 

--- a/src/test/java/com/artipie/pypi/meta/PackageInfoFromMetadataTest.java
+++ b/src/test/java/com/artipie/pypi/meta/PackageInfoFromMetadataTest.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.pypi.meta;
+
+import org.cactoos.io.InputStreamOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.llorllale.cactoos.matchers.MatcherOf;
+
+/**
+ * Test for {@link com.artipie.pypi.meta.PackageInfo.FromMetadata}.
+ * @since 0.6
+ * @checkstyle LeftCurlyCheck (500 lines)
+ */
+class PackageInfoFromMetadataTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "my-project,0.3",
+        "Another project,123-93",
+        "Very-very-difficult project,3"
+    })
+    void readsMetadata(final String name, final String version) {
+        MatcherAssert.assertThat(
+            new PackageInfo.FromMetadata(new InputStreamOf(this.metadata(name, version))),
+            Matchers.allOf(
+                new MatcherOf<>(info -> { return version.equals(info.version()); }),
+                new MatcherOf<>(info -> { return name.equals(info.name()); })
+            )
+        );
+    }
+
+    @Test
+    void throwsExceptionIfInfoNotFound() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new PackageInfo.FromMetadata(new InputStreamOf("some text")).name()
+        );
+    }
+
+    private String metadata(final String name, final String version) {
+        return String.join(
+            "\n",
+            "Metadata-Version: 2.1",
+            String.format("Name: %s", name),
+            String.format("Version: %s", version),
+            "Summary: A sample Python project",
+            "Author: Someone",
+            "Author-email: someone@example.com"
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/pypi/meta/package-info.java
+++ b/src/test/java/com/artipie/pypi/meta/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Pypi meta files tests.
+ *
+ * @since 0.6
+ */
+package com.artipie.pypi.meta;


### PR DESCRIPTION
Part of #86: read project name and version from metadata. Python metadata is a single set of RFC-822 headers as specified by [PEP-314](https://www.python.org/dev/peps/pep-0314/).