### PR TITLE
#129 - test for proxy with pip

### DIFF
--- a/src/main/java/com/artipie/pypi/http/PyProxySlice.java
+++ b/src/main/java/com/artipie/pypi/http/PyProxySlice.java
@@ -75,11 +75,8 @@ public final class PyProxySlice extends Slice.Wrap {
         super(
             new SliceRoute(
                 new RtRulePath(
-                    new RtRule.All(
-                        new ByMethodsRule(RqMethod.GET),
-                        new RtRule.ByPath("(^\\/)|(.*(\\/[a-z0-9\\-]+?\\/?$))")
-                    ),
-                    new IndexProxySlice(
+                    new ByMethodsRule(RqMethod.GET),
+                    new ProxySlice(
                         new AuthClientSlice(new UriClientSlice(clients, remote), auth),
                         new FromRemoteCache(cache)
                     )

--- a/src/test/java/com/artipie/pypi/http/ProxySliceTest.java
+++ b/src/test/java/com/artipie/pypi/http/ProxySliceTest.java
@@ -46,12 +46,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test for {@link IndexProxySlice}.
+ * Test for {@link ProxySlice}.
  * @since 0.7
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-class IndexProxySliceTest {
+class ProxySliceTest {
 
     /**
      * Test storage.
@@ -69,7 +69,7 @@ class IndexProxySliceTest {
         final String key = "index";
         MatcherAssert.assertThat(
             "Returns body from remote",
-            new IndexProxySlice(
+            new ProxySlice(
                 new SliceSimple(new RsWithBody(StandardRs.OK, new Content.From(body))),
                 new FromRemoteCache(this.storage)
             ),
@@ -87,12 +87,12 @@ class IndexProxySliceTest {
 
     @Test
     void getsFromCacheOnError() {
-        final byte[] body = "my project index".getBytes();
+        final byte[] body = "my project package".getBytes();
         final String key = "my_project";
         this.storage.save(new Key.From(key), new Content.From(body)).join();
         MatcherAssert.assertThat(
             "Returns body from cache",
-            new IndexProxySlice(
+            new ProxySlice(
                 new SliceSimple(new RsWithStatus(RsStatus.INTERNAL_ERROR)),
                 new FromRemoteCache(this.storage)
             ),
@@ -113,7 +113,7 @@ class IndexProxySliceTest {
         final RsStatus status = RsStatus.BAD_REQUEST;
         MatcherAssert.assertThat(
             "Status 400 returned",
-            new IndexProxySlice(
+            new ProxySlice(
                 new SliceSimple(new RsWithStatus(status)),
                 new FromRemoteCache(this.storage)
             ),

--- a/src/test/java/com/artipie/pypi/http/PyProxySliceITCase.java
+++ b/src/test/java/com/artipie/pypi/http/PyProxySliceITCase.java
@@ -47,6 +47,8 @@ import org.hamcrest.text.StringContainsInOrder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.testcontainers.Testcontainers;
 
 /**
@@ -97,6 +99,7 @@ final class PyProxySliceITCase {
     }
 
     @Test
+    @EnabledOnOs({OS.LINUX, OS.MAC})
     void installsFromProxy() throws IOException, InterruptedException {
         Testcontainers.exposeHostPorts(this.port);
         try (PypiContainer runtime = new PypiContainer()) {


### PR DESCRIPTION
Part of #129 
Added proxy IT using pip install, renamed `IndexProxySlice` to `ProxySlice` as it should be used for any requests. Also as pip requires content-type header to be present in response, I've proxyed this header from remote.