### PR TITLE
#149 - return 404 on absent content in proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.30</version>
+      <version>0.32</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>


### PR DESCRIPTION
Closes #149 
I've updated `asto`, now 404 status is returned on any problems while getting content from remote or cache.